### PR TITLE
Add aarch64 dist-files

### DIFF
--- a/aarch64/latest
+++ b/aarch64/latest
@@ -1,0 +1,1 @@
+https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz

--- a/aarch64/latest-dev
+++ b/aarch64/latest-dev
@@ -1,0 +1,1 @@
+https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz

--- a/aarch64/latest.html
+++ b/aarch64/latest.html
@@ -1,0 +1,15 @@
+<!DOCTYPE HTML>
+<html lang="en-US">
+    <head>
+        <meta charset="UTF-8">
+        <meta http-equiv="refresh" content="1;https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz">
+        <script type="text/javascript">
+            window.location.href = "https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz";
+        </script>
+        <title>Page Redirection</title>
+    </head>
+    <body>
+        <!-- Note: don't tell people to `click` the link, just tell them that it is a link. -->
+        If you are not redirected automatically, follow the <a href='https://github.com/MycroftAI/mycroft-precise/releases/download/v0.3.0/precise-engine_0.3.0_aarch64.tar.gz'>link</a>.
+    </body>
+</html>

--- a/aarch64/precise-engine_0.3.0_aarch64.tar.gz.md5
+++ b/aarch64/precise-engine_0.3.0_aarch64.tar.gz.md5
@@ -1,0 +1,1 @@
+7cf02d3875f28cec7a81a443311aca37  precise-engine_0.3.0_aarch64.tar.gz


### PR DESCRIPTION
This adds the reference files for the aarch64 built version. I've also added these to the 0.3.0 release in the mycroft-precise repository.

Let me know if I've messed up in any way here.